### PR TITLE
chores: Add GPS entry in uses-feature

### DIFF
--- a/bee/src/main/AndroidManifest.xml
+++ b/bee/src/main/AndroidManifest.xml
@@ -35,6 +35,11 @@
         android:glEsVersion="0x00020000"
         android:required="true" />
 
+    <uses-feature
+        android:name="android.hardware.location.gps" />
+    <uses-feature
+        android:name="android.hardware.location.network" />
+
     <application
         android:name="com.apisense.bee.BeeApplication"
         android:allowBackup="true"

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.0'
         classpath 'com.google.gms:google-services:3.0.0'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8' // Used by ButterKnife
     }


### PR DESCRIPTION
Android now request apps for API 21+ to request
GPS usage with ACCESS_FINE_LOCATION permission.
See: https://developer.android.com/guide/topics/location/strategies.html#Permission