### PR TITLE
feat: Add reset password button & handle email validation

### DIFF
--- a/bee/src/main/java/com/apisense/bee/ui/activity/LoginActivity.java
+++ b/bee/src/main/java/com/apisense/bee/ui/activity/LoginActivity.java
@@ -40,11 +40,17 @@ public class LoginActivity extends AppCompatActivity
     }
 
     @Override
-    public void switchToLogin() {
+    public void switchToLogin(String email, String password) {
         LoginFragment loginFragment = new LoginFragment();
+        getIntent().putExtra(LoginFragment.LOGIN_EMAIL_KW, email);
+        getIntent().putExtra(LoginFragment.LOGIN_PASSWORD_KW, password);
         loginFragment.setArguments(getIntent().getExtras());
         getSupportFragmentManager().beginTransaction()
                 .replace(R.id.fragment_container, loginFragment).commit();
+    }
+
+    public void switchToLogin() {
+        switchToLogin(null, null);
     }
 
     @Override

--- a/bee/src/main/res/layout/fragment_login.xml
+++ b/bee/src/main/res/layout/fragment_login.xml
@@ -74,6 +74,14 @@
             android:id="@+id/signInPassword"
             android:hint="@string/password"  />
 
+        <TextView
+            android:id="@+id/forgot_password_button"
+            android:textColor="@color/aps_white"
+            android:textAppearance="@android:style/TextAppearance.DeviceDefault.Small"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/forgotten_password"/>
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -101,7 +109,7 @@
 
             <com.facebook.login.widget.LoginButton
                 android:id="@+id/fb_login_button"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_gravity="center_horizontal"
                 android:layout_marginEnd="@dimen/activity_horizontal_margin"
@@ -111,13 +119,11 @@
                 android:layout_marginBottom="@dimen/activity_vertical_margin"
                 android:layout_marginTop="@dimen/activity_vertical_margin"
                 android:paddingTop="12dp"
-                android:paddingBottom="12dp"
-                android:paddingLeft="15dp"
-                android:paddingRight="15dp" />
+                android:paddingBottom="12dp" />
 
             <com.google.android.gms.common.SignInButton
                 android:id="@+id/google_login_button"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
                 android:layout_marginEnd="@dimen/activity_horizontal_margin"
@@ -130,7 +136,6 @@
 
     </LinearLayout>
 
-
     <!-- Footer -->
 
     <LinearLayout
@@ -141,7 +146,7 @@
         android:gravity="center_horizontal|center_vertical">
 
         <TextView
-            android:text="Everything you share in Bee is anonymous !"
+            android:text="@string/anonymous_share"
             android:textColor="@color/aps_white"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/bee/src/main/res/values-fr/strings.xml
+++ b/bee/src/main/res/values-fr/strings.xml
@@ -45,6 +45,11 @@
     <string name="passwordConfirm">Confirmez mot de passe</string>
     <string name="registration_not_implemented">Ce type d\'inscription n\'est pas encore disponible.</string>
     <string name="social_networks">Ou connectez vous avec votre réseau social favori:</string>
+    <string name="forgotten_password">Mot de passe oublié?</string>
+    <string name="missing_email_address">Veuillez renseigner votre adresse email</string>
+    <string name="mail_incoming">Un email devrait arriver d\'ici peu</string>
+    <string name="validation_mail_incoming">Vous allez recevoir un email afin de confirmer votre adresse</string>
+    <string name="anonymous_share">Tout ce que vous partagez avec bee est anonyme !</string>
 
     <!-- Slides text -->
     <string name="slide_welcome_back">Bonjour</string>

--- a/bee/src/main/res/values/strings.xml
+++ b/bee/src/main/res/values/strings.xml
@@ -63,6 +63,11 @@
     <string name="passwordConfirm">Confirm password</string>
     <string name="registration_not_implemented">This kind of registration is not enabled yet.</string>
     <string name="social_networks">Or sign in with your favorite social network:</string>
+    <string name="forgotten_password">Forgot your password?</string>
+    <string name="missing_email_address">Please fill in your email address</string>
+    <string name="mail_incoming">A mail should arrive shortly</string>
+    <string name="validation_mail_incoming">You will receive an email to confirm your address</string>
+    <string name="anonymous_share">Everything you share in Bee is anonymous !</string>
 
     <!-- Slides text -->
     <string name="slide_welcome_back">Welcome back</string>


### PR DESCRIPTION
This button will use the form email if pressed,
if no email is present, it will ask for one.

When creating a user, the application will
redirect the user to login fragment with email
and password filled in, waiting for the validation mail.

This commit also lightly improve code on LoginFragment
- Remove useless constructor
- Avoid useless multiple calls on *EditText.getText()
- field content are not anymore attributes