### PR TITLE
fix: Add '-dontwarn org.sl4j.**' to proguard

### DIFF
--- a/bee/proguard-rules.pro
+++ b/bee/proguard-rules.pro
@@ -59,6 +59,10 @@
 -keep class org.mozilla.javascript.** { *; }
 -dontwarn org.mozilla.javascript.**
 -dontwarn sun.**
+
+## JDeferred
+-dontwarn org.slf4j.**
+
 # End apisense
 ##############
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,5 +15,6 @@ allprojects {
         jcenter()
         maven { url '/tmp/sdkRepo/content/repositories/snapshots/' }
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" } // APISENSE Snapshots
+        mavenLocal()
     }
 }


### PR DESCRIPTION
This enables [jdeferred](https://github.com/jdeferred/jdeferred) to run correctly