### PR TITLE
Fix the sensor drawing process to handle more icons

### DIFF
--- a/bee/src/main/java/com/apisense/bee/ui/adapter/SubscribedExperimentsRecyclerAdapter.java
+++ b/bee/src/main/java/com/apisense/bee/ui/adapter/SubscribedExperimentsRecyclerAdapter.java
@@ -97,7 +97,7 @@ public class SubscribedExperimentsRecyclerAdapter extends
         @BindView(R.id.crop_title) TextView mCropTitle;
         @BindView(R.id.crop_owner) TextView mCropOwner;
         @BindView(R.id.crop_description) TextView mCropDescription;
-        @BindView(R.id.sensors_container) LinearLayout mSensorsContainer;
+        @BindView(R.id.sensors_container) ViewGroup mSensorsContainer;
 
         public ViewHolder(View itemView) {
             super(itemView);

--- a/bee/src/main/java/com/apisense/bee/ui/fragment/CommonDetailsFragment.java
+++ b/bee/src/main/java/com/apisense/bee/ui/fragment/CommonDetailsFragment.java
@@ -6,7 +6,6 @@ import android.support.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -30,7 +29,7 @@ public class CommonDetailsFragment extends BaseFragment {
     @BindView(R.id.crop_detail_title) TextView nameView;
     @BindView(R.id.crop_detail_owner_and_version) TextView organizationView;
     @BindView(R.id.crop_detail_description) TextView descriptionView;
-    @BindView(R.id.crop_sensors_detail_container) LinearLayout stingGridView;
+    @BindView(R.id.crop_sensors_detail_container) ViewGroup stingGridView;
 
     protected Crop crop;
     protected APISENSE.Sdk apisenseSdk;

--- a/bee/src/main/java/com/apisense/bee/ui/layout/SensorsLayout.java
+++ b/bee/src/main/java/com/apisense/bee/ui/layout/SensorsLayout.java
@@ -1,0 +1,85 @@
+package com.apisense.bee.ui.layout;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
+
+public class SensorsLayout extends ViewGroup {
+    private int lineHeight;
+
+    public static class LayoutParams extends ViewGroup.LayoutParams {
+        public LayoutParams(int width, int height) {
+            super(width, height);
+        }
+    }
+
+    public SensorsLayout(Context context) {
+        super(context);
+    }
+
+    public SensorsLayout(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        int width = MeasureSpec.getSize(widthMeasureSpec) - getPaddingLeft() - getPaddingRight();
+
+        int count = getChildCount();
+
+        int xPosition = getPaddingLeft();
+        int yPosition = getPaddingTop();
+
+        for (int i = 0; i < count; i++) {
+            View child = getChildAt(i);
+
+            if (child.getVisibility() == GONE) {
+                continue;
+            }
+
+            LayoutParams layoutParams = (LayoutParams) child.getLayoutParams();
+
+            lineHeight = Math.max(lineHeight, layoutParams.height);
+
+            if (xPosition + layoutParams.width > width) {
+                xPosition = getPaddingLeft();
+                yPosition += layoutParams.height;
+            }
+
+            xPosition = xPosition + layoutParams.width;
+        }
+
+        int height = yPosition + lineHeight;
+
+        setMeasuredDimension(width, height);
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        int count = getChildCount();
+        int width = right - left;
+        int xPosition = getPaddingLeft();
+        int yPosition = getPaddingTop();
+
+
+        for (int i = 0; i < count; i++) {
+            View child = getChildAt(i);
+
+            if (child.getVisibility() == GONE) {
+                continue;
+            }
+
+            LayoutParams layoutParams = (LayoutParams) child.getLayoutParams();
+
+            if (xPosition + layoutParams.width > width) {
+                xPosition = getPaddingLeft();
+                yPosition = yPosition + lineHeight;
+            }
+
+            child.layout(xPosition, yPosition, xPosition + layoutParams.width, yPosition + layoutParams.height);
+
+            xPosition = xPosition + layoutParams.width;
+        }
+    }
+}

--- a/bee/src/main/java/com/apisense/bee/utils/SensorsDrawer.java
+++ b/bee/src/main/java/com/apisense/bee/utils/SensorsDrawer.java
@@ -2,12 +2,14 @@ package com.apisense.bee.utils;
 
 import android.content.Context;
 import android.content.res.Resources;
+import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
-import android.support.v7.widget.RecyclerView;
 import android.util.DisplayMetrics;
 import android.view.ViewGroup;
 import android.widget.ImageView;
+
+import com.apisense.bee.ui.layout.SensorsLayout;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -18,26 +20,18 @@ import java.util.Set;
 import io.apisense.sting.lib.Sensor;
 
 public class SensorsDrawer {
-    private static final int SENSOR_LATERAL_PADDING = 2;
-    private static final float SENSOR_DISABLED_ALPHA = 0.1f;
+    private static final int SENSOR_SIZE = 27;
+    private static final int SENSOR_PADDING = 4;
+    private static final float SENSOR_ALPHA = 0.6f;
+
     private final Set<Sensor> availableSensors;
     private final int sensorSize;
-    private final int lateralPadding;
+    private final int sensorPadding;
 
     public SensorsDrawer(Set<Sensor> availableSensors) {
         this.availableSensors = availableSensors;
-        this.sensorSize = sensorDimension(availableSensors.size());
-        this.lateralPadding = dpToPx(SENSOR_LATERAL_PADDING);
-    }
-
-    /**
-     * Retrieve the sensor dimension to set in order to make them all fit on the screen.
-     *
-     * @param sensorNumber The number of sensor to draw.
-     * @return The size in pixels to use for each sensor.
-     */
-    private static int sensorDimension(int sensorNumber) {
-        return (Resources.getSystem().getDisplayMetrics().widthPixels - (2 * dpToPx(SENSOR_LATERAL_PADDING))) / (sensorNumber + 1);
+        sensorSize = dpToPx(SENSOR_SIZE);
+        sensorPadding = dpToPx(SENSOR_PADDING);
     }
 
     /**
@@ -52,8 +46,8 @@ public class SensorsDrawer {
         if (view.getChildCount() != 0) {
             view.removeAllViews();
         }
-        drawSensors(context, view, usedStings);
 
+        drawSensors(context, view, usedStings);
     }
 
     /**
@@ -65,13 +59,10 @@ public class SensorsDrawer {
      */
     private void drawSensors(Context context, ViewGroup view, List<String> usedStings) {
         for (Sensor sensor : asSortedList(availableSensors)) {
-            ImageView sensorView = parametrizedSensorView(context, sensor);
-
-            if (!usedStings.contains(sensor.stingName)) {
-                sensorView.setAlpha(SENSOR_DISABLED_ALPHA);
+            if (usedStings.contains(sensor.stingName)) {
+                ImageView sensorView = parametrizedSensorView(context, sensor);
+                view.addView(sensorView);
             }
-
-            view.addView(sensorView);
         }
     }
 
@@ -86,10 +77,15 @@ public class SensorsDrawer {
     private ImageView parametrizedSensorView(Context context, Sensor sensor) {
         ImageView sensorView = new ImageView(context);
 
-        RecyclerView.LayoutParams params = new RecyclerView.LayoutParams(sensorSize, sensorSize);
-        sensorView.setImageDrawable(ContextCompat.getDrawable(context, sensor.iconID));
+        SensorsLayout.LayoutParams params = new SensorsLayout.LayoutParams(sensorSize, sensorSize);
         sensorView.setLayoutParams(params);
-        sensorView.setPadding(this.lateralPadding, 0, this.lateralPadding, 0);
+
+        Drawable drawable = ContextCompat.getDrawable(context, sensor.iconID);
+        sensorView.setImageDrawable(drawable);
+        sensorView.setPadding(sensorPadding, 0, sensorPadding, 0);
+
+        sensorView.setAlpha(SENSOR_ALPHA);
+
         return sensorView;
     }
 

--- a/bee/src/main/res/layout/fragment_common_details.xml
+++ b/bee/src/main/res/layout/fragment_common_details.xml
@@ -18,13 +18,12 @@
             android:gravity="center_horizontal"
             android:textSize="@dimen/secondary_title_size"/>
 
-        <LinearLayout
+        <com.apisense.bee.ui.layout.SensorsLayout
             android:id="@+id/crop_sensors_detail_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:gravity="center_horizontal"
-            android:orientation="horizontal">
-        </LinearLayout>
+            android:gravity="center_horizontal">
+        </com.apisense.bee.ui.layout.SensorsLayout>
 
         <View
             android:layout_width="match_parent"

--- a/bee/src/main/res/layout/list_item_home_experiment.xml
+++ b/bee/src/main/res/layout/list_item_home_experiment.xml
@@ -43,12 +43,11 @@
         android:textColor="@color/aps_secondary_text"
         android:layout_below="@+id/crop_owner"/>
 
-    <LinearLayout
+    <com.apisense.bee.ui.layout.SensorsLayout
         android:id="@+id/sensors_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
         android:layout_below="@id/crop_description">
-    </LinearLayout>
+    </com.apisense.bee.ui.layout.SensorsLayout>
 
 </RelativeLayout>

--- a/bee/src/main/res/layout/list_item_store_experiment.xml
+++ b/bee/src/main/res/layout/list_item_store_experiment.xml
@@ -52,11 +52,10 @@
         android:maxLines="2"
         android:textColor="@color/aps_secondary_text"/>
 
-    <LinearLayout
+    <com.apisense.bee.ui.layout.SensorsLayout
         android:id="@+id/store_sensors_container"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-    </LinearLayout>
+        android:layout_height="wrap_content">
+    </com.apisense.bee.ui.layout.SensorsLayout>
 
 </LinearLayout>


### PR DESCRIPTION
Sensor icons are now rendered in multiple row if the number is high.
Only the sensors that are used are drawn.

Before | After
:-------------------------:|:-------------------------:
![screenshot_20171012-143630](https://user-images.githubusercontent.com/8227507/31496239-e8c1148a-af5a-11e7-9ecb-2a7090016db3.png)  |  ![screenshot_20171012-143313](https://user-images.githubusercontent.com/8227507/31496272-0be59d14-af5b-11e7-9704-d190d8f39ded.png)
![screenshot_20171012-143634](https://user-images.githubusercontent.com/8227507/31496241-ebc6ca94-af5a-11e7-99ab-3fed34ed3d35.png) | ![screenshot_20171012-141113](https://user-images.githubusercontent.com/8227507/31496278-10122bc8-af5b-11e7-94e5-68a8deaf7f4a.png)
