### PR TITLE
Fix bad padding on the home details view

### DIFF
--- a/bee/src/main/res/layout/fragment_home_details.xml
+++ b/bee/src/main/res/layout/fragment_home_details.xml
@@ -4,7 +4,10 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:gravity="center_horizontal"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:layout_marginLeft="@dimen/activity_horizontal_margin"
+    android:layout_marginRight="@dimen/activity_horizontal_margin"
+    android:layout_marginTop="@dimen/activity_vertical_margin">
 
     <include layout="@layout/fragment_common_details" />
 


### PR DESCRIPTION
Fix the home details view by adding the default padding.

Before | After
:-------------------------:|:-------------------------:
![screenshot_20171016-100658](https://user-images.githubusercontent.com/8227507/31601710-1170bacc-b25b-11e7-97c0-b71f0c55986d.png) | ![screenshot_20171016-100727](https://user-images.githubusercontent.com/8227507/31601748-38ae7552-b25b-11e7-9411-97d766f4faea.png)

