### PR TITLE
Fix UI bug that did not update the state of the crop (btn start/stop)

### DIFF
--- a/bee/src/main/java/com/apisense/bee/ui/fragment/HomeDetailsFragment.java
+++ b/bee/src/main/java/com/apisense/bee/ui/fragment/HomeDetailsFragment.java
@@ -114,7 +114,7 @@ public class HomeDetailsFragment extends CommonDetailsFragment {
                 doSubscribeUnsubscribe();
                 break;
             case R.id.detail_action_update:
-                doUpdate();
+                doStopUpdate();
                 break;
         }
         return false;
@@ -148,6 +148,20 @@ public class HomeDetailsFragment extends CommonDetailsFragment {
         } else {
             cropPermissionHandler.startOrRequestPermissions();
         }
+    }
+
+    private void doStopUpdate() {
+        if (apisenseSdk.getCropManager().isRunning(crop)) {
+            apisenseSdk.getCropManager().stop(crop, new OnCropStopped(getActivity()) {
+                @Override
+                public void onDone(Crop crop) {
+                    super.onDone(crop);
+                    displayStartButton();
+                }
+            });
+        }
+
+        doUpdate();
     }
 
     private void displayStopButton() {


### PR DESCRIPTION
To reproduce the bug:
- Start a crop.
- Click on the button "update".

-> The state of the crop is not updated (the button indicating the state of the crop is always on play).

Before updating, I stop the crop if it is running and then update it.