### PR TITLE
fix: Miscellaneous crashes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ ext {
     apkCode = 28
 
     // Libraries
-    apisenseVersion = "1.11.6"
+    apisenseVersion = "1.11.7"
     googleServicesVersion = "11.6.2"
     androidSupportVersion = "27.0.1"
 }


### PR DESCRIPTION
Use logger instead of rollbar for API < 19 to avoid a crash on startup
Also integrate the new SDK version, fixing bugs about notifications, Sting exceptions and adding a rollbar exception report.

Closes #41, #43 